### PR TITLE
1.0.1-pl - Fix converting and create assets

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -23,7 +23,7 @@ if (!defined('MOREPROVIDER_BUILD')) {
     /* define version */
     define('PKG_NAME', 'Commerce_AbandonedCart');
     define('PKG_NAMESPACE', 'commerce_abandonedcart');
-    define('PKG_VERSION', '1.0.0');
+    define('PKG_VERSION', '1.0.1');
     define('PKG_RELEASE', 'pl');
 
     /* load modx */
@@ -113,17 +113,24 @@ if (is_array($settings)) {
     unset($settings,$setting,$attributes);
 }
 
+$category = $modx->newObject('modCategory');
+$category->set('category', PKG_NAMESPACE);
+
+$vehicle = $builder->createVehicle($category, $attributes);
+
 // Add the validator to check server requirements
 // $vehicle->validate('php', array('source' => $sources['validators'] . 'requirements.script.php'));
 
-//$vehicle->resolve('file',array(
-//    'source' => $sources['source_assets'],
-//    'target' => "return MODX_ASSETS_PATH . 'components/';",
-//));
 $vehicle->resolve('file',array(
-    'source' => $sources['source_core'],
-    'target' => "return MODX_CORE_PATH . 'components/';",
+    'source' => $sources['source_assets'],
+    'target' => "return MODX_ASSETS_PATH . 'components/';",
 ));
+$modx->log(modX::LOG_LEVEL_INFO,'Packaged in assets.'); flush();
+
+//$vehicle->resolve('file',array(
+//    'source' => $sources['source_core'],
+//    'target' => "return MODX_CORE_PATH . 'components/';",
+//));
 /*$vehicle->resolve('php',array(
     'source' => $sources['resolvers'] . 'loadmodules.resolver.php',
 ));*/

--- a/core/components/commerce_abandonedcart/docs/changelog.txt
+++ b/core/components/commerce_abandonedcart/docs/changelog.txt
@@ -1,5 +1,9 @@
 ++ Abandoned Cart for Commerce
 
+++ v1.0.1-pl - released on 05/21/2021
+++++++++++++++++++++++++++
+- Fix converting carts and create assets
+
 ++ v1.0.0-pl - released on 10/23/2020
 ++++++++++++++++++++++++++
-- Initiial release
+- Initial release

--- a/core/components/commerce_abandonedcart/src/Modules/AbandonedCart.php
+++ b/core/components/commerce_abandonedcart/src/Modules/AbandonedCart.php
@@ -160,9 +160,9 @@ class AbandonedCart extends BaseModule {
      * @param \modmore\Commerce\Events\Payment $event
      * @return void
      */
-    public function convertAbandonedCartToProcessing(\modmore\Commerce\Events\Payment $event)
+    public function convertAbandonedCartToProcessing(\modmore\Commerce\Events\OrderState $state)
     {
-        $this->convertAbandonedCart($event->getOrder());
+        $this->convertAbandonedCart($state->getOrder());
     }
 
     /**


### PR DESCRIPTION
There is one call for `Commerce::EVENT_STATE_CART_TO_PROCESSING` in `core/components/commerce/model/commerce/comcartorder.class.php`. And this call use as argument `\modmore\Commerce\Events\OrderState` - not `\modmore\Commerce\Events\Payment`

And package builder does not create assets dir for component. In this PR builder will put `assets` to the package.